### PR TITLE
Restructure gin-admin-experience to use Navigation module, not Admin Toolbar.  TW 29747626

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,6 @@
     "require": {
         "drupal/core": ">=10.4",
         "drupal/gin": "^3.0@RC",
-        "drupal/gin_login": "^2.1",
-        "drupal/navigation": "^11.1"
+        "drupal/gin_login": "^2.1"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -10,10 +10,9 @@
         }
     ],
     "require": {
-        "drupal/admin_toolbar": "^3.5",
         "drupal/core": ">=10.4",
         "drupal/gin": "^3.0@RC",
         "drupal/gin_login": "^2.1",
-        "drupal/gin_toolbar": "^1.0@RC"
+        "drupal/navigation": "^11.1"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
     "require": {
         "drupal/core": ">=10.4",
         "drupal/gin": "^3.0@RC",
-        "drupal/gin_login": "^2.1"
+        "drupal/gin_login": "^2.1",
+        "drupal/navigation_extra_tools": "^1.0"
     }
 }

--- a/recipe.yml
+++ b/recipe.yml
@@ -10,7 +10,7 @@ install:
   # Install Gin theme and base modules that extend it.
   - gin
   - gin_login
-  # Install Layout Builder as it is ia dependency of Navigation.
+  # Install Layout Builder as it is a dependency of Navigation.
   - layout_builder
   # Install Navigation Module.
   - navigation

--- a/recipe.yml
+++ b/recipe.yml
@@ -22,7 +22,6 @@ config:
     # Import all of Navigation modules config.
     navigation: '*'
     # Import all of Gin and Gin Login's config.
-    # Gin Toolbar does not have any config.
     gin:
       - gin.settings
       - block.block.gin_breadcrumbs

--- a/recipe.yml
+++ b/recipe.yml
@@ -7,23 +7,20 @@ install:
   - help
   # Install Claro as it is a dependency of Gin, but don't import config.
   - claro
-  # Install Toolbar as it is a dependency of Gin Toolbar.
-  - toolbar
-  - admin_toolbar
-  - admin_toolbar_search
-  - admin_toolbar_tools
   # Install Gin theme and base modules that extend it.
   - gin
   - gin_login
-  - gin_toolbar
+  # Install Layout Builder as it is ia dependency of Navigation.
+  - layout_builder
+  # Install Navigation Module.
+  - navigation
 config:
   # Allow config import to continue if config already exists.
   strict: false
   import:
-    # Import all of Admin Toolbar's modules config.
-    admin_toolbar: '*'
-    admin_toolbar_search: '*'
-    admin_toolbar_tools: '*'
+    # Import all of Navigation modules config.
+    navigation: '*'
+    layout_builder: '*'
     # Import all of Gin and Gin Login's config.
     # Gin Toolbar does not have any config.
     gin:

--- a/recipe.yml
+++ b/recipe.yml
@@ -21,7 +21,6 @@ config:
   import:
     # Import all of Navigation modules config.
     navigation: '*'
-    layout_builder: '*'
     # Import all of Gin and Gin Login's config.
     # Gin Toolbar does not have any config.
     gin:

--- a/recipe.yml
+++ b/recipe.yml
@@ -12,8 +12,9 @@ install:
   - gin_login
   # Install Layout Builder as it is a dependency of Navigation.
   - layout_builder
-  # Install Navigation Module.
+  # Install Navigation Modules.
   - navigation
+  - navigation_extra_tools
 config:
   # Allow config import to continue if config already exists.
   strict: false


### PR DESCRIPTION
…instead

## Description
Teamwork Ticket(s): [Restructure gin-admin-experience to use Navigation module, not Admin Toolbar.](https://kanopi.teamwork.com/app/tasks/29747626#)
Removes Toolbar and Gin admin toolbar and uses core Navigation module instead

## Deploy Notes
https://github.com/kanopi/gin-admin-experience/pull/8
